### PR TITLE
Add support for cortex-m0-plus

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
@@ -8,6 +8,10 @@ ifeq ($(TARGET_ARCH), cortex-m0)
   CORE=M0
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M0
 
+else ifeq ($(TARGET_ARCH), cortex-m0plus)
+  CORE=M0plus
+  ARM_LDFLAGS := -Wl,--cpu=Cortex-M0plus
+
 else ifeq ($(TARGET_ARCH), cortex-m3)
   CORE=M3
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M3


### PR DESCRIPTION
Pulling this in from the upstream tensorflow system so that OpenMV can build firmware for the m0plus.